### PR TITLE
Fix : user_guard 구현

### DIFF
--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -24,7 +24,6 @@ describe('AuthService', () => {
       password: 'mypassword',
     };
     await userService.create(dto);
-
     const validated = await authService.validateUser(dto.email, dto.password);
     expect(validated).toBeDefined();
     const validatedRec = validated as Record<string, unknown>;
@@ -43,10 +42,16 @@ describe('AuthService', () => {
       password: 'tokentest',
     };
     await userService.create(dto);
-    const stored = userService.findByEmail(dto.email);
-    expect(stored).toBeDefined();
+    const validatedUser = await authService.validateUser(
+      dto.email,
+      dto.password,
+    );
+    expect(validatedUser).toBeDefined();
 
-    const tokenRes = authService.login({ id: stored!.id, email: dto.email });
+    const tokenRes = authService.login({
+      id: validatedUser!.id,
+      email: dto.email,
+    });
     expect(tokenRes).toHaveProperty('access_token');
     const payload = authService.validateToken(tokenRes.access_token);
     expect(payload).toHaveProperty('sub');

--- a/backend/src/modules/user/user.module.ts
+++ b/backend/src/modules/user/user.module.ts
@@ -2,9 +2,10 @@ import { Module, forwardRef } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../../prisma/prisma.module';
 
 @Module({
-  imports: [forwardRef(() => AuthModule)],
+  imports: [PrismaModule, forwardRef(() => AuthModule)],
   providers: [UserService],
   controllers: [UserController],
   exports: [UserService],

--- a/backend/src/modules/user/user.service.spec.ts
+++ b/backend/src/modules/user/user.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { UserService } from './user.service';
+import { UserEntity } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 
 describe('UserService', () => {
@@ -23,11 +24,13 @@ describe('UserService', () => {
     const createdRec = created as Record<string, unknown>;
     expect(createdRec.password).toBeUndefined();
 
-    const stored = service.findByEmail(dto.email);
+    const stored = (await service.findByEmail(
+      dto.email,
+    )) as unknown as UserEntity;
     expect(stored).toBeDefined();
-    expect(stored?.password).not.toEqual(dto.password);
+    expect(stored.password).not.toEqual(dto.password);
 
-    const valid = await service.validatePassword(stored!, dto.password);
+    const valid = await service.validatePassword(stored, dto.password);
     expect(valid).toBe(true);
   });
 
@@ -48,9 +51,11 @@ describe('UserService', () => {
       password: 'password123',
     };
     await service.create(dto);
-    const stored = service.findByEmail(dto.email);
+    const stored = (await service.findByEmail(
+      dto.email,
+    )) as unknown as UserEntity;
     expect(stored).toBeDefined();
-    const byId = service.findById(stored!.id);
+    const byId = await service.findById(stored.id);
     expect(byId.email).toEqual(dto.email);
 
     expect(() => service.findById('non-existent-id')).toThrow(

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -4,56 +4,109 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { UserEntity } from './entities/user.entity';
+import { User as PrismaUser } from '@prisma/client';
 import { CreateUserDto } from './dto/create-user.dto';
 import * as bcrypt from 'bcrypt';
+import { PrismaService } from '../../prisma/prisma.service';
 
 @Injectable()
 export class UserService {
-  private users: Map<string, UserEntity> = new Map();
+  private useMemory: boolean;
+  private users: Map<string, UserEntity> | null = null;
+
+  constructor(private readonly prismaService?: PrismaService) {
+    this.useMemory = !prismaService || process.env.NODE_ENV === 'test';
+    if (this.useMemory) {
+      this.users = new Map<string, UserEntity>();
+    }
+  }
 
   async create(dto: CreateUserDto): Promise<Omit<UserEntity, 'password'>> {
-    const existing = Array.from(this.users.values()).find(
-      (u) => u.email === dto.email,
-    );
+    if (this.useMemory && this.users) {
+      const existing = Array.from(this.users.values()).find(
+        (u) => u.email === dto.email,
+      );
+      if (existing) throw new ConflictException('이미 등록된 이메일입니다.');
+
+      const hashed = await bcrypt.hash(dto.password, 10);
+      let id: string;
+      if (process.env.NODE_ENV === 'test') {
+        id = `test-${Math.random().toString(36).substring(2, 10)}`;
+      } else {
+        const { v4: uuidv4 } = await import('uuid');
+        id = uuidv4();
+      }
+
+      const user = new UserEntity({
+        id,
+        email: dto.email,
+        password: hashed,
+        name: dto.name,
+        avatar: dto.avatar,
+        role: 'GUEST',
+        verified: false,
+      });
+
+      this.users.set(user.id, user);
+      const { password: _password, ...rest } = user;
+      void _password;
+      return rest;
+    }
+
+    // Prisma-backed
+    const prisma = this.prismaService!;
+    const existing = await prisma.user.findUnique({
+      where: { email: dto.email },
+    });
     if (existing) throw new ConflictException('이미 등록된 이메일입니다.');
 
     const hashed = await bcrypt.hash(dto.password, 10);
-    let id: string;
-    if (process.env.NODE_ENV === 'test') {
-      id = `test-${Math.random().toString(36).substring(2, 10)}`;
-    } else {
-      const { v4: uuidv4 } = await import('uuid');
-      id = uuidv4();
-    }
 
-    const user = new UserEntity({
-      id,
-      email: dto.email,
-      password: hashed,
-      name: dto.name,
-      avatar: dto.avatar,
-      role: 'user',
-      verified: false,
+    const created = await prisma.user.create({
+      data: {
+        email: dto.email,
+        password: hashed,
+        name: dto.name ?? '',
+        avatar: dto.avatar ?? null,
+      },
     });
 
-    this.users.set(user.id, user);
-
-    const { password: _password, ...rest } = user;
+    const { password: _password, ...rest } = created as unknown as UserEntity;
     void _password;
     return rest;
   }
 
-  findByEmail(email: string): UserEntity | undefined {
-    return Array.from(this.users.values()).find((u) => u.email === email);
+  findByEmail(
+    email: string,
+  ): UserEntity | undefined | Promise<UserEntity | undefined> {
+    if (this.useMemory && this.users) {
+      return Array.from(this.users.values()).find((u) => u.email === email);
+    }
+    const prisma = this.prismaService!;
+    return prisma.user.findUnique({ where: { email } }) as Promise<
+      UserEntity | undefined
+    >;
   }
 
-  findById(id: string): UserEntity {
-    const user = this.users.get(id);
-    if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
-    return user;
+  findById(id: string): UserEntity | Promise<UserEntity> {
+    if (this.useMemory && this.users) {
+      const user = this.users.get(id);
+      if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      return user;
+    }
+    const prisma = this.prismaService!;
+    return (async () => {
+      const user = await prisma.user.findUnique({ where: { id } });
+      if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      return user as unknown as UserEntity;
+    })();
   }
 
-  async validatePassword(user: UserEntity, plain: string): Promise<boolean> {
-    return await bcrypt.compare(plain, user.password);
+  async validatePassword(
+    user: { password: string } | UserEntity | PrismaUser,
+    plain: string,
+  ): Promise<boolean> {
+    const pwd = (user as { password: string }).password;
+    return await bcrypt.compare(plain, pwd);
   }
 }

--- a/backend/src/rooms/rooms.controller.ts
+++ b/backend/src/rooms/rooms.controller.ts
@@ -6,14 +6,14 @@ import {
   Patch,
   Param,
   Delete,
-  // UseGuards,
+  UseGuards,
   Request,
 } from '@nestjs/common';
 import { Request as ExpressRequest } from 'express';
 import { RoomsService } from './rooms.service';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
-// import { AuthGuard } from '@nestjs/passport';
+import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 interface AuthenticatedRequest extends ExpressRequest {
@@ -28,6 +28,8 @@ export class RoomsController {
   // @UseGuards(AuthGuard('jwt'))
   // @ApiBearerAuth()
   @ApiOperation({ summary: '숙소 생성' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
   @Post()
   create(
     @Request() req: AuthenticatedRequest,
@@ -35,7 +37,7 @@ export class RoomsController {
   ) {
     // 인증서비스가 완료되면 사용자아이디를 사용
     // const hostId = req.user.id;
-    const hostId = 'df5046ea-61ef-4c0b-96f1-13c43c37d9b7';
+    const hostId = req.user?.id;
     return this.roomsService.create(createRoomDto, hostId);
   }
 
@@ -51,19 +53,26 @@ export class RoomsController {
     return this.roomsService.findOne(id);
   }
 
-  // @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   @ApiOperation({ summary: '숙소 수정' })
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateRoomDto: UpdateRoomDto) {
-    return this.roomsService.update(id, updateRoomDto);
+  update(
+    @Request() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Body() updateRoomDto: UpdateRoomDto,
+  ) {
+    // 권한은 서비스 레이어에서 검증합니다. 현재는 인증된 사용자 ID를 전달합니다.
+    const userId = req.user?.id;
+    return this.roomsService.update(id, updateRoomDto, userId);
   }
 
-  // @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   @ApiOperation({ summary: '숙소 삭제' })
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.roomsService.remove(id);
+  remove(@Request() req: AuthenticatedRequest, @Param('id') id: string) {
+    const userId = req.user?.id;
+    return this.roomsService.remove(id, userId);
   }
 }


### PR DESCRIPTION
토큰없이 room 생성시 401 반환

# PR 템플릿

> PR 작성 전에 아래 컨벤션(브랜치/커밋/PR 제목)과 lint 통과 여부를 확인해 주세요.

## 📘 PR 제목 규칙

- PR 제목은 프로젝트 컨벤션을 따릅니다. 예: `[Feat] Tool List Card 공통 컴포넌트 구현`
- 브랜치 이름과 커밋 메시지 규칙도 컨벤션에 맞게 작성해주세요.

## 🔎 변경 내용

 user_guard 구현

## ✅ 체크리스트

- [x] PR 제목 컨벤션을 확인했습니다 (README의 "Branch/PR/Commit" 규칙)
- [x] 브랜치 이름 컨벤션을 확인했습니다
- [x] 커밋 메시지 컨벤션을 확인했습니다
- [x] 코드 스타일(ESLint/Prettier)을 적용했습니다
- [x] CI에서 lint가 통과해야 병합합니다 (자동으로 실행됩니다)
- [x] 필요한 경우 테스트를 추가하거나 기존 테스트를 확인했습니다
- [x] 리뷰어/Assignee를 지정했습니다

## 📌 관련 이슈

- close # (연결된 이슈 번호가 있으면 작성)

## 📸 스크린샷 / 데모

<img width="1214" height="817" alt="image" src="https://github.com/user-attachments/assets/3b607fff-eddf-400f-ab9d-5db121712d7f" />


---

참고: 프로젝트의 컨벤션 문서는 `README.md`에 정리되어 있습니다. PR을 올리기 전에 컨벤션과 lint를 확인해주세요.
